### PR TITLE
Enhance trip planner

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 
         <!-- ✅ Liste des étapes -->
         <h2>Étapes</h2>
-        <ul id="etapes-list"></ul>
+        <div id="etapes-list"></div>
 
         <!-- ✅ Itinéraire -->
         <div id="itineraire-info"></div>

--- a/styles.css
+++ b/styles.css
@@ -63,11 +63,19 @@ aside h2 {
 }
 
 #etapes-list {
+    padding: 0;
+}
+
+.day-section {
+    margin-bottom: 20px;
+}
+
+.day-section ul {
     list-style: none;
     padding: 0;
 }
 
-#etapes-list li {
+.day-section li {
     background-color: #eee;
     margin-bottom: 10px;
     padding: 8px;
@@ -80,7 +88,7 @@ aside h2 {
     height: 100vh;
 }
 
-#etapes-list li button.supprimer {
+.day-section li button.supprimer {
     float: right;
     background-color: #ff4d4d;
     color: white;
@@ -91,7 +99,7 @@ aside h2 {
     cursor: pointer;
 }
 
-#etapes-list li button.supprimer:hover {
+.day-section li button.supprimer:hover {
     background-color: #cc0000;
 }
 
@@ -124,4 +132,8 @@ aside h2 {
     padding: 4px 6px;
     cursor: pointer;
     border-radius: 3px;
+}
+
+.day-nav {
+    margin-left: 5px;
 }


### PR DESCRIPTION
## Summary
- enable multi-day planning of steps
- group steps by day and allow editing notes
- drag markers on map to adjust route
- style day sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68476b10b5308323acad99089cf9fbd8