### PR TITLE
Add shareable itinerary and persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
         <!-- ✅ Barre de recherche -->
         <input id="search" type="text" placeholder="Rechercher un lieu...">
         <button id="reset">Réinitialiser</button>
+        <button id="share">Partager</button>
 
         <!-- ✅ Liste des étapes -->
         <h2>Étapes</h2>


### PR DESCRIPTION
## Summary
- store itinerary in localStorage whenever it changes
- reload saved itinerary on start or from URL
- add share button to generate encoded URL
- parse encoded URL data on load

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68476b0828ac832389976ada1f3be13f